### PR TITLE
Correction du TimeOut

### DIFF
--- a/core/class/wazeintime.class.php
+++ b/core/class/wazeintime.class.php
@@ -42,7 +42,7 @@ class wazeintime extends eqLogic {
 					$wazeRouteurl = 'https://www.waze.com/' . $row . 'RoutingManager/routingRequest?from=x%3A' . $start['lon'] . '+y%3A' . $start['lat'] . '&to=x%3A' . $end['lon'] . '+y%3A' . $end['lat'] . '&at=0&returnJSON=true&returnGeometries=true&returnInstructions=true&timeout=60000&nPaths=3&options=AVOID_TRAILS%3At';
 					$request_http = new com_http($wazeRouteurl);
 					$request_http->setUserAgent('User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:43.0) Gecko/20100101 Firefox/43.0');
-					$json = json_decode($request_http->exec(6,2), true);
+					$json = json_decode($request_http->exec(60,2), true);
 					if (isset($json['error'])) {
 						throw new Exception($json['error']);
 					}
@@ -51,7 +51,7 @@ class wazeintime extends eqLogic {
 					$wazeRoutereturl = 'https://www.waze.com/' . $row . 'RoutingManager/routingRequest?from=x%3A' . $end['lon'] . '+y%3A' . $end['lat'] . '&to=x%3A' . $start['lon'] . '+y%3A' . $start['lat'] . '&at=0&returnJSON=true&returnGeometries=true&returnInstructions=true&timeout=60000&nPaths=3&options=AVOID_TRAILS%3At';
 					$request_http = new com_http($wazeRoutereturl);
 					$request_http->setUserAgent('User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:43.0) Gecko/20100101 Firefox/43.0');
-					$json = json_decode($request_http->exec(6,2), true);
+					$json = json_decode($request_http->exec(60,2), true);
 					if (isset($json['error'])) {
 						throw new Exception($json['error']);
 					}


### PR DESCRIPTION
Pour ne plus avoir d'erreur du plugin dans Jeedom lorsque la réponse de Waze met plus de 6s, passage à 60s de timeout.